### PR TITLE
Add Rust solutions for Two pointers 

### DIFF
--- a/rust/Two Pointers/shift_zeros_to_the_end.rs
+++ b/rust/Two Pointers/shift_zeros_to_the_end.rs
@@ -1,0 +1,15 @@
+fn shift_zeros_to_the_end(nums: &mut Vec<i32>) {
+    // The 'left' pointer is used to position non-zero elements.
+    let mut left = 0;
+
+    // Iterate through the array using a 'right' pointer to locate non-zero
+    // elements.
+    for right in 0..nums.len() {
+        if nums[right] != 0 {
+            nums.swap(left, right);
+            // Increment 'left' since it now points to a position already occupied
+            // by a non-zero element.
+            left += 1;
+        }
+    }
+}

--- a/rust/Two Pointers/shift_zeros_to_the_end_naive.rs
+++ b/rust/Two Pointers/shift_zeros_to_the_end_naive.rs
@@ -1,0 +1,17 @@
+fn shift_zeros_to_the_end_naive(nums: &mut Vec<i32>) {
+    let mut temp = vec![0; nums.len()];
+    let mut i = 0;
+
+    // Add all non-zero elements to the left of 'temp'.
+    for num in nums.iter() {
+        if *num != 0 {
+            temp[i] = *num;
+            i += 1;
+        }
+    }
+
+    // Set 'nums' to 'temp'.
+    for j in 0..nums.len() {
+        nums[j] = temp[j];
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds Rust solution for:
`shift_zeros_to_the_end.rs`
`shift_zeros_to_the_end_naive.rs`

## Changes
- Implemented solutions following Rust best practices

## Checklist

- [X] Algorithm logic matches Python versions
- [X] Memory safe (no unsafe code)
- [X] Follows Rust conventions
- [X] Comments