### PR TITLE
Add missing Rust implementations for Two Pointers

### DIFF
--- a/rust/Two Pointers/largest_container_brute_force.rs
+++ b/rust/Two Pointers/largest_container_brute_force.rs
@@ -1,0 +1,13 @@
+fn largest_container_brute_force(heights: Vec<i32>) -> i32 {
+    let n = heights.len();
+    let mut max_water = 0;
+
+    // Find the maximum amount of water stored between all pairs of lines.
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let water = heights[i].min(heights[j]) * (j as i32 - i as i32);
+            max_water = max_water.max(water);
+        }
+    }
+    max_water
+}

--- a/rust/Two Pointers/next_lexicographical_sequence.rs
+++ b/rust/Two Pointers/next_lexicographical_sequence.rs
@@ -1,0 +1,35 @@
+fn next_lexicographical_sequence(s: &str) -> String {
+    let mut letters: Vec<char> = s.chars().collect();
+
+    // Locate the pivot, which is the first character from the right that breaks
+    // non-increasing order. Start searching from the second-to-last position.
+    let mut pivot = letters.len() - 2;
+    while pivot < letters.len() && letters[pivot] >= letters[pivot + 1] {
+        if pivot == 0 {
+            break;
+        }
+        pivot -= 1;
+    }
+
+    // If pivot is not found, the string is already in its largest permutation. In
+    // this case, reverse the string to obtain the smallest permutation.
+    if pivot == 0 && letters[pivot] >= letters[pivot + 1] {
+        letters.reverse();
+        return letters.into_iter().collect();
+    }
+
+    // Find the rightmost successor to the pivot.
+    let mut rightmost_successor = letters.len() - 1;
+    while letters[rightmost_successor] <= letters[pivot] {
+        rightmost_successor -= 1;
+    }
+
+    // Swap the rightmost successor with the pivot to increase the lexicographical
+    // order of the suffix.
+    letters.swap(pivot, rightmost_successor);
+
+    // Reverse the suffix after the pivot to minimize its permutation.
+    letters[(pivot + 1)..].reverse();
+
+    letters.into_iter().collect()
+}

--- a/rust/Two Pointers/pair_sum_sorted_brute_force.rs
+++ b/rust/Two Pointers/pair_sum_sorted_brute_force.rs
@@ -1,0 +1,12 @@
+fn pair_sum_sorted_brute_force(nums: Vec<i32>, target: i32) -> Vec<i32> {
+    let n = nums.len();
+
+    for i in 0..n {
+        for j in (i + 1)..n {
+            if nums[i] + nums[j] == target {
+                return vec![i as i32, j as i32];
+            }
+        }
+    }
+    vec![]
+}

--- a/rust/Two Pointers/triplet_sum_brute_force.rs
+++ b/rust/Two Pointers/triplet_sum_brute_force.rs
@@ -1,0 +1,22 @@
+use std::collections::HashSet;
+
+fn triplet_sum_brute_force(nums: Vec<i32>) -> Vec<Vec<i32>> {
+    let n = nums.len();
+    let mut triplets = HashSet::new();
+
+    // Iterate through the indexes of all triplets.
+    for i in 0..n {
+        for j in (i + 1)..n {
+            for k in (j + 1)..n {
+                if nums[i] + nums[j] + nums[k] == 0 {
+                    // Sort the triplet before including it in the hash set.
+                    let mut triplet = vec![nums[i], nums[j], nums[k]];
+                    triplet.sort();
+                    triplets.insert(triplet);
+                }
+            }
+        }
+    }
+
+    triplets.into_iter().collect()
+}


### PR DESCRIPTION
## Description
This PR adds the missing Rust implementations for the Two Pointers pattern to complete the Rust implementation and match the Python3 structure.

## Changes Made
- Added `largest_container_brute_force.rs` - Brute force approach for container with most water problem
- Added `next_lexicographical_sequence.rs` - Next lexicographical permutation algorithm  
- Added `pair_sum_sorted_brute_force.rs` - Brute force approach for finding pair sum in sorted array
- Added `triplet_sum_brute_force.rs` - Brute force approach for finding triplets that sum to zero

## Files Added
- `rust/Two Pointers/largest_container_brute_force.rs`
- `rust/Two Pointers/next_lexicographical_sequence.rs`
- `rust/Two Pointers/pair_sum_sorted_brute_force.rs`
- `rust/Two Pointers/triplet_sum_brute_force.rs`

