### PR TITLE
Add Rust implementations for Linked Lists patterns (Part 1)

### DIFF
--- a/rust/Linked Lists/flatten_multi_level_list.rs
+++ b/rust/Linked Lists/flatten_multi_level_list.rs
@@ -1,0 +1,45 @@
+#[derive(Debug)]
+struct MultiLevelListNode {
+    val: i32,
+    next: Option<Box<MultiLevelListNode>>,
+    child: Option<Box<MultiLevelListNode>>,
+}
+
+impl MultiLevelListNode {
+    fn new(val: i32) -> Self {
+        MultiLevelListNode {
+            val,
+            next: None,
+            child: None,
+        }
+    }
+}
+
+fn flatten_multi_level_list(
+    head: Option<Box<MultiLevelListNode>>,
+) -> Option<Box<MultiLevelListNode>> {
+    if head.is_none() {
+        return None;
+    }
+    let mut head = head;
+    let mut tail = head.as_mut().unwrap();
+    // Find the tail of the linked list at the first level.
+    while let Some(ref next) = tail.next {
+        tail = tail.next.as_ref().unwrap();
+    }
+    let mut curr = head.as_mut().unwrap();
+    // Process each node at the current level. If a node has a child linked list,
+    // append it to the tail and then update the tail to the end of the extended
+    // linked list. Continue until all nodes at the current level are processed.
+    while let Some(ref mut current) = curr.next {
+        if let Some(child) = current.child.take() {
+            tail.next = Some(child);
+            // Update tail to the end of the child list
+            while let Some(ref next) = tail.next {
+                tail = tail.next.as_ref().unwrap();
+            }
+        }
+        curr = current;
+    }
+    head
+}

--- a/rust/Linked Lists/linked_list_intersection.rs
+++ b/rust/Linked Lists/linked_list_intersection.rs
@@ -1,0 +1,44 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug)]
+struct ListNode {
+    val: i32,
+    next: Option<Rc<RefCell<ListNode>>>,
+}
+
+impl ListNode {
+    fn new(val: i32) -> Rc<RefCell<Self>> {
+        Rc::new(RefCell::new(ListNode { val, next: None }))
+    }
+}
+
+fn linked_list_intersection(
+    head_a: Option<Rc<RefCell<ListNode>>>,
+    head_b: Option<Rc<RefCell<ListNode>>>,
+) -> Option<Rc<RefCell<ListNode>>> {
+    let mut ptr_a = head_a.clone();
+    let mut ptr_b = head_b.clone();
+    // Traverse through list A with 'ptr_a' and list B with 'ptr_b'
+    // until they meet.
+    while ptr_a != ptr_b {
+        // Traverse list A -> list B by first traversing 'ptr_a' and
+        // then, upon reaching the end of list A, continue the
+        // traversal from the head of list B.
+        ptr_a = if let Some(node) = ptr_a {
+            node.borrow().next.clone()
+        } else {
+            head_b.clone()
+        };
+        // Simultaneously, traverse list B -> list A.
+        ptr_b = if let Some(node) = ptr_b {
+            node.borrow().next.clone()
+        } else {
+            head_a.clone()
+        };
+    }
+    // At this point, 'ptr_a' and 'ptr_b' either point to the
+    // intersection node or both are null if the lists do not
+    // intersect. Return either pointer.
+    ptr_a
+}

--- a/rust/Linked Lists/linked_list_reversal.rs
+++ b/rust/Linked Lists/linked_list_reversal.rs
@@ -1,0 +1,32 @@
+#[derive(Debug)]
+struct ListNode {
+    val: i32,
+    next: Option<Box<ListNode>>,
+}
+
+impl ListNode {
+    fn new(val: i32) -> Self {
+        ListNode {
+            val,
+            next: None,
+        }
+    }
+}
+
+fn linked_list_reversal(head: Option<Box<ListNode>>) -> Option<Box<ListNode>> {
+    let mut curr_node = head;
+    let mut prev_node = None;
+
+    // Reverse the direction of each node's pointer until 'curr_node'
+    // is null.
+    while let Some(mut current) = curr_node {
+        let next_node = current.next.take();
+        current.next = prev_node;
+        prev_node = Some(current);
+        curr_node = next_node;
+    }
+
+    // 'prev_node' will be pointing at the head of the reversed linked
+    // list.
+    prev_node
+}

--- a/rust/Linked Lists/linked_list_reversal_recursive.rs
+++ b/rust/Linked Lists/linked_list_reversal_recursive.rs
@@ -1,0 +1,30 @@
+#[derive(Debug)]
+struct ListNode {
+    val: i32,
+    next: Option<Box<ListNode>>,
+}
+
+impl ListNode {
+    fn new(val: i32) -> Self {
+        ListNode { val, next: None }
+    }
+}
+
+fn linked_list_reversal_recursive(head: Option<Box<ListNode>>) -> Option<Box<ListNode>> {
+    // Base cases.
+    if head.is_none() || head.as_ref().unwrap().next.is_none() {
+        return head;
+    }
+    // Recursively reverse the sublist starting from the next node.
+    let mut current = head.unwrap();
+    let next = current.next.take();
+    let new_head = linked_list_reversal_recursive(next);
+    // Connect the reversed linked list to the head node to fully
+    // reverse the entire linked list.
+    if let Some(mut next_node) = new_head {
+        next_node.next = Some(current);
+        Some(next_node)
+    } else {
+        Some(current)
+    }
+}


### PR DESCRIPTION
**Summary**
This PR adds Rust implementations for Linked Lists coding interview patterns, translating the existing Python solutions to idiomatic Rust code.

**Files Added**
- `rust/Linked Lists/flatten_multi_level_list.rs`
- `rust/Linked Lists/linked_list_intersection.rs`
- `rust/Linked Lists/linked_list_reversal.rs` 
- `rust/Linked Lists/linked_list_reversal_recursive.rs `

**Data Structures*

- Used `Box<T>` for owned nodes in simple cases
- Used `Rc<RefCell<T>>` for shared mutable references (intersection detection)
- Proper memory management with Rust's ownership system

*Key Features*
- Maintained algorithmic complexity equivalent to python versions
- Maintained comments as in python version

