### PR TITLE
Replace suboptimal O(n) time/space inorder vector approach with O(k + h) time, O(h) space recursive solution that short-circuits once the kth smallest is found

### DIFF
--- a/cpp/Trees/kth_smallest_number_in_BST_recursive.cpp
+++ b/cpp/Trees/kth_smallest_number_in_BST_recursive.cpp
@@ -1,4 +1,3 @@
-#include <vector>
 #include "ds/TreeNode.h"
 using ds::TreeNode;
 
@@ -12,19 +11,22 @@ using ds::TreeNode;
  *     TreeNode(int x, TreeNode *left, TreeNode *right) : val(x), left(left), right(right) {}
  * };
  */
+void kthSmallest(TreeNode* node, int& k, int& smallest) {
+    if (!node) return;
 
-int kthSmallestNumberInBSTRecursive(TreeNode* root, int k) {
-    std::vector<int> sortedList = inorder(root);
-    return sortedList[k - 1];
+    kthSmallest(node->left, k, smallest);
+
+    if (k == 0) return; // short-circuit: answer found in left subtree
+    if (--k == 0) {
+        smallest = node->val;
+        return;
+    }
+
+    kthSmallest(node->right, k, smallest);
 }
 
-// Inorder traversal function to attain a sorted list of nodes from the BST.
-std::vector<int> inorder(TreeNode* node) {
-    if (!node)
-        return {};
-    std::vector<int> left = inorder(node->left);
-    left.push_back(node->val);
-    std::vector<int> right = inorder(node->right);
-    left.insert(left.end(), right.begin(), right.end());
-    return left;
+int kthSmallestNumberInBSTRecursive(TreeNode* root, int k) {
+    int smallest = root->val;
+    kthSmallest(root, k, smallest);
+    return smallest;
 }


### PR DESCRIPTION
The previous implementation collected all node values into a vector via a full inorder traversal before indexing into it, resulting in O(n) time and O(n) space regardless of where the kth smallest element sits in the tree.

The new implementation passes `k` by reference as a countdown and short-circuits as soon as it reaches zero. When the kth node is found, the `return` prevents any further right subtree traversal in that frame. For ancestors that were waiting on a left call, the `if (k == 0) return` guard intercepts them before they descend right, ensuring no unnecessary nodes are visited after the answer is found.

This brings time complexity down to O(k + h) and space complexity down to O(h), where h is the height of the tree. In the worst case (skewed tree) h = n, but for balanced trees this is a significant improvement over the previous approach.